### PR TITLE
improv: global modeler error type, finer-grained errors, using `thiserror`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 /Cargo.lock
 /.vscode
 /*.code-workspace
-/ink-stroke-modeler/build
+/docs/*.pdf
 /test
 /expand

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ svg = "0.16.0"
 tracing = "0.1.40"
 
 [dependencies]
+thiserror = "1.0.61"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![main docs](https://img.shields.io/badge/docs-main-informational)](https://flxzt.github.io/ink-stroke-modeler-rs/ink_stroke_modeler_rs/)
 [![CI](https://github.com/flxzt/ink-stroke-modeler-rs/actions/workflows/ci.yaml/badge.svg)](https://github.com/flxzt/ink-stroke-modeler-rs/actions/workflows/ci.yaml)
 
-Partial rust rewrite of [https://github.com/google/ink-stroke-modeler](https://github.com/google/ink-stroke-modeler). Beware that not all functionalities are implemented (no kalman-based prediction) and the API is not identical either. 
+Partial rust rewrite of [https://github.com/google/ink-stroke-modeler](https://github.com/google/ink-stroke-modeler).
+Beware that not all functionalities are implemented (no kalman-based prediction) and the API is not identical either.
 
 # Usage
 

--- a/docs/position_modeling.html
+++ b/docs/position_modeling.html
@@ -13,7 +13,7 @@ position modeling</p>
 <p>The position of the pen is modeled as a weight connected by a spring
 to an anchor.</p>
 <p>The anchor moves along the <em>resampled dewobbled inputs</em>,
-pulling the weight along with it accross a surface, with some amount of
+pulling the weight along with it across a surface, with some amount of
 friction. Euler integration is used to solve for the position of the
 pen.</p>
 <figure>

--- a/docs/position_modeling.typ
+++ b/docs/position_modeling.typ
@@ -17,7 +17,7 @@
 #definition[
 The position of the pen is modeled as a weight connected by a spring to an anchor.
 
-The anchor moves along the _resampled dewobbled inputs_, pulling the weight along with it accross a surface, with some
+The anchor moves along the _resampled dewobbled inputs_, pulling the weight along with it across a surface, with some
 amount of friction. Euler integration is used to solve for the position of the pen.
 
 #figure(image("position_model.svg"))

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
-# build docs
-doc:
+# justfile for ink-stroke-modeler-rs crate
+
+default:
+    just --list
+
+docs-build:
     pandoc docs/notations.typ -o docs/notations.html --mathml
     pandoc docs/position_modeling.typ -o docs/position_modeling.html --mathml
     pandoc docs/resampling.typ -o docs/resampling.html --mathml
@@ -9,8 +13,7 @@ doc:
     cargo doc --open
     cp docs/position_model.svg target/doc/ink_stroke_modeler_rs/position_model.svg
 
-
-remove_html:
+docs-remove-html:
     rm docs/notations.html
     rm docs/position_modeling.html
     rm docs/resampling.html

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -435,7 +435,7 @@ impl StrokeModeler {
                 if self.wobble_duration_sum < 1e-12 {
                     event.pos
                 } else {
-                    // calulate the average position
+                    // calculate the average position
 
                     let avg_position = (
                         self.wobble_weighted_pos_sum.0 / self.wobble_duration_sum,
@@ -992,7 +992,7 @@ mod tests {
             ]
         ));
 
-        // we get more strokes as the model catches up to the anchor postion
+        // we get more strokes as the model catches up to the anchor position
         time += delta_time;
         let update = engine.update(ModelerInput {
             event_type: ModelerInputEventType::Up,
@@ -1105,7 +1105,7 @@ mod tests {
             ]
         ));
 
-        // the stroke is finised, we get an error if we predict it
+        // the stroke is finished, we get an error if we predict it
         assert!(engine.predict().is_err());
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub enum ElementError {
         #[from]
         src: ElementOrderError,
     },
-    #[error("Sent element's time is too far apart from the previous one.")]
+    #[error("Sent element's time is too far apart from the previous one")]
     TooFarApart,
 }
 
@@ -18,11 +18,11 @@ pub enum ElementError {
 #[non_exhaustive]
 #[allow(clippy::enum_variant_names)]
 pub enum ElementOrderError {
-    #[error("Down Event is not the first or occured after a different event")]
+    #[error("Down Event is not the first or occurred after a different event")]
     UnexpectedDown,
-    #[error("Move event occured before a initial down event")]
+    #[error("Move event occurred before a initial down event")]
     UnexpectedMove,
-    #[error("No other event occured before an up event")]
+    #[error("No other event occurred before an up event")]
     UnexpectedUp,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-/// Modeler Element Error
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum ElementError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,38 @@
+/// Modeler Element Error
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum ElementError {
+    #[error("A duplicate element is sent to the modeler")]
+    Duplicate,
+    #[error("A sent element has a time earlier than the previous one")]
+    NegativeTimeDelta,
+    #[error("Sent element order is incorrect")]
+    Order {
+        #[from]
+        src: ElementOrderError,
+    },
+    #[error("Sent element's time is too far apart from the previous one.")]
+    TooFarApart,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+#[allow(clippy::enum_variant_names)]
+pub enum ElementOrderError {
+    #[error("Down Event is not the first or occured after a different event")]
+    UnexpectedDown,
+    #[error("Move event occured before a initial down event")]
+    UnexpectedMove,
+    #[error("No other event occured before an up event")]
+    UnexpectedUp,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum ModelerError {
+    #[error("Input element error")]
+    Element {
+        #[from]
+        src: ElementError,
+    },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // Modules
 mod engine;
-mod error;
+pub mod error;
 mod input;
 mod params;
 mod position_modeler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,6 @@
-// imports
-use std::collections::VecDeque;
-
-#[cfg(test)]
-extern crate approx;
-
-// modules
+// Modules
 mod engine;
+mod error;
 mod input;
 mod params;
 mod position_modeler;
@@ -13,12 +8,13 @@ mod results;
 mod state_modeler;
 mod utils;
 
-pub use engine::Errors;
+#[cfg(test)]
+extern crate approx;
+
+// Re-Exports
 pub use engine::StrokeModeler;
+pub use error::ModelerError;
 pub use input::ModelerInput;
 pub use input::ModelerInputEventType;
 pub use params::ModelerParams;
-use position_modeler::PositionModeler;
-use results::ModelerPartial;
 pub use results::ModelerResult;
-use state_modeler::StateModeler;

--- a/src/params.rs
+++ b/src/params.rs
@@ -137,13 +137,10 @@ impl ModelerParams {
             Ok(self)
         } else {
             //Collect errors
-            let error_acc = parameter_tests
-                .iter()
-                .zip(errors)
-                .filter(|x| !*(x.0))
-                .fold(String::from("the following errors occured : "), |acc, x| {
-                    acc + x.1
-                });
+            let error_acc = parameter_tests.iter().zip(errors).filter(|x| !*(x.0)).fold(
+                String::from("the following errors occurred : "),
+                |acc, x| acc + x.1,
+            );
 
             Err(error_acc)
         }

--- a/src/position_modeler.rs
+++ b/src/position_modeler.rs
@@ -515,7 +515,7 @@ fn test_update_linear_path() {
 }
 
 #[test]
-fn model_end_of_stroke_stationnary() {
+fn model_end_of_stroke_stationary() {
     let mut model = PositionModeler::new(
         ModelerParams::suggested(),
         ModelerInput {

--- a/src/position_modeler.rs
+++ b/src/position_modeler.rs
@@ -1,5 +1,6 @@
+use crate::results::ModelerPartial;
 use crate::utils::{dist, nearest_point_on_segment};
-use crate::{ModelerInput, ModelerParams, ModelerPartial};
+use crate::{ModelerInput, ModelerParams};
 
 /// This struct models the movement of the pen tip based on the laws of motion.
 /// The pen tip is represented as a mass, connected by a spring to a moving

--- a/src/state_modeler.rs
+++ b/src/state_modeler.rs
@@ -1,13 +1,12 @@
 use crate::utils::{dist, interp, interp2, nearest_point_on_segment};
 use crate::ModelerInput;
+use std::collections::VecDeque;
 
 // only imported for docstrings
 #[allow(unused)]
-use crate::ModelerPartial;
+use crate::results::ModelerPartial;
 #[allow(unused)]
 use crate::ModelerResult;
-
-use std::collections::VecDeque;
 
 /// Get the pressure for a position by querying
 /// information from the raw input strokes


### PR DESCRIPTION
This refactors the errors into a separate module, restructures them a bit and introduces a crate-wide `ModelerError` intended to be returned in all results in the crate - currently it only holds the `ElementError` variant, but allows for future additions.
All error types are deriving the [thiserror](https://docs.rs/thiserror/latest/thiserror/) Error trait, improving their messages and general handling.
